### PR TITLE
BAH-523 The Login List Page shows passwords in plain text

### DIFF
--- a/openelis/WebContent/pages/login/loginUser.jsp
+++ b/openelis/WebContent/pages/login/loginUser.jsp
@@ -53,7 +53,7 @@ function validateForm(form) {
 							<bean:message key="login.password"/>:<span class="requiredlabel">*</span>
 						</td>	
 						<td>
-							<html:text name="<%=formName%>" property="password" size="20" maxlength="80"/>
+							<html:password name="<%=formName%>" property="password" size="20" maxlength="80"/>
 						</td>
         </tr>
         <tr>						

--- a/openelis/WebContent/pages/login/loginUserMenu.jsp
+++ b/openelis/WebContent/pages/login/loginUserMenu.jsp
@@ -21,9 +21,6 @@
 	   	  <bean:message key="login.login.name"/>
 	   </th>
 	   <th>
-	   	  <bean:message key="login.password"/>
-	   </th>
-	   <th>
 	   	  <bean:message key="login.password.expired.date"/>
 	   </th>
 	   <th>
@@ -50,9 +47,6 @@
    	   </td>	  
 	   <td class="textcontent">
 	   	  <bean:write name="login" property="loginName"/>
-	   </td>
-	   <td class="textcontent">
-	   	  <bean:write name="login" property="password"/>
 	   </td>
 	   <td class="textcontent">
 	   	  <bean:write name="login" property="passwordExpiredDateForDisplay"/>


### PR DESCRIPTION
- Login as admin user
- Navigate to https://demo.mybahmni.org/openelis/LoginUserMenu.do
- this page shows the password column in encrypted sha
- Edit a particular user.  The password is seen in clear text.

This PR masks the password and removes the encrypted password column in list page.

https://bahmni.atlassian.net/browse/BAH-523