### PR TITLE
BAH-1118 | OpenELIS error during QA deployment

### DIFF
--- a/openelis/src/us/mn/state/health/lims/test/valueholder/Test.hbm.xml
+++ b/openelis/src/us/mn/state/health/lims/test/valueholder/Test.hbm.xml
@@ -45,7 +45,7 @@
             <column name="DESCRIPTION" length="60" not-null="true" unique="true" />
         </property>
         <property name="referenceInfo" type="java.lang.String">
-            <column name="reference_Info" length="240" not-null="true" unique="true" />
+            <column name="reference_Info" length="240" />
         </property>
         <property name="loinc" type="java.lang.String">
             <column name="LOINC" length="240" />


### PR DESCRIPTION
OpenELIS error during QA deployment,  it is because in "openelis/src/us/mn/state/health/lims/test/valueholder/Test.hbm.xml" file by mistake i put the not-null and unique property true which is not needed for referenceInfo column. Only in Test.hbm.xml change is needed and remove these constraints. In liquibase and other places it is fine.