### PR TITLE
BDI-29 | Add | Checkout action for default_config

### DIFF
--- a/.github/workflows/ci-v0.94.yml
+++ b/.github/workflows/ci-v0.94.yml
@@ -71,11 +71,11 @@ jobs:
           ref: ${{ env.BRANCH_NAME }}
           path: bahmni-scripts
       - name: Checkout default-config
-          uses: actions/checkout@v2
-          with:
-            repository: Bahmni/default-config
-            ref: ${{ env.BRANCH_NAME }}
-            path: default-config
+        uses: actions/checkout@v2
+        with:
+          repository: Bahmni/default-config
+          ref: ${{ env.BRANCH_NAME }}
+          path: default-config
       - uses: actions/download-artifact@v2
         with:
           name: openelis-war


### PR DESCRIPTION
This PR adds an additional step which checkouts default-config repo for baking in default image of OpenELIS.