### PR TITLE
BAH-2436 | Use amazoncorretto as base image

### DIFF
--- a/package/docker/openelis/Dockerfile
+++ b/package/docker/openelis/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-alpine
+FROM amazoncorretto:8
 
 ENV SERVER_PORT=8052
 ENV BASE_DIR=/var/run/bahmni-lab
@@ -15,6 +15,7 @@ RUN mkdir -p ${WAR_DIRECTORY}
 RUN mkdir -p /opt/bahmni-lab/migrations/db_backup/
 RUN mkdir -p /opt/bahmni-lab/migrations/liquibase/
 RUN mkdir -p /opt/bahmni-lab/migrations/scripts/
+RUN yum install -y unzip
 
 ADD https://repo.mybahmni.org/packages/build/bahmni-embedded-tomcat-8.0.42.jar /opt/bahmni-lab/lib/bahmni-lab.jar
 COPY openelis/dist/openelis.war /etc/bahmni-lab/openelis.war
@@ -25,7 +26,7 @@ RUN cp -r /tmp/artifacts/default_config/openelis/. /etc/bahmni_config/openelis/
 RUN cd ${WAR_DIRECTORY} && jar xvf /etc/bahmni-lab/openelis.war
 
 # Used by envsubst command for replacing environment values at runtime
-RUN apk add gettext
+RUN yum install -y gettext
 
 COPY package/docker/openelis/templates/hibernate.cfg.xml.template /etc/bahmni-lab/
 COPY package/docker/openelis/templates/atomfeed.properties.template /etc/bahmni-lab/


### PR DESCRIPTION
Using amazoncorreto as baseimage since openjdk builds has beeen deprecated. More info [here](https://talk.openmrs.org/t/using-amazoncorretto-as-base-image-for-bahmni-docker-images/37668).

Co-authored-by: Divij Goyal [divij.g@beehyv.com](mailto:divij.g@beehyv.com)