### PR TITLE
BAH-2851 | Fix. Unknown field properties error on reference data sync

### DIFF
--- a/openelis/src/org/bahmni/feed/openelis/feed/contract/bahmnireferencedata/ReferenceDataTestAndPanels.java
+++ b/openelis/src/org/bahmni/feed/openelis/feed/contract/bahmnireferencedata/ReferenceDataTestAndPanels.java
@@ -3,7 +3,9 @@ package org.bahmni.feed.openelis.feed.contract.bahmnireferencedata;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ReferenceDataTestAndPanels {
 
     private List<ReferenceDataTest> tests;


### PR DESCRIPTION
This PR fixes the following error when syncing lab and panels from OpenMRS. This happens due to OMRS upgrade to 2.5.x.

```us.mn.state.health.lims.common.exception.LIMSRuntimeException: Unrecognized field "properties" (class org.bahmni.feed.openelis.feed.contract.bahmnireferencedata.ReferenceDataTestAndPanels), not marked as ignorable (7 known properties: "isActive", "tests", "lastUpdated", "dateCreated", "id", "panels", "name"])```