### PR TITLE
BAH-3367 | Fix. Workflow failures and build errors

### DIFF
--- a/.github/workflows/build_publish_openelis.yml
+++ b/.github/workflows/build_publish_openelis.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '7'
-      - name: Setup Ruby 2.3
+      - name: Setup Ruby 2.5
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.3

--- a/openelis/src/us/mn/state/health/lims/common/util/SafeRequest.java
+++ b/openelis/src/us/mn/state/health/lims/common/util/SafeRequest.java
@@ -6,6 +6,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
+import java.util.Arrays;
+import java.util.List;
 
 public class SafeRequest extends HttpServletRequestWrapper {
 


### PR DESCRIPTION
This PR fixes errors in workflow install & build step.
- Upgraded Ruby version from 2.3 --> 2.5 as compass installation requires Ruby 2.5
- Fixed import error which is caused by #50 