### PR TITLE
BAH-3379 | Add script to update host and port config of OpenMRS

### DIFF
--- a/package/docker/openelis/Dockerfile
+++ b/package/docker/openelis/Dockerfile
@@ -17,7 +17,10 @@ RUN mkdir -p /home/bahmni/uploaded_results/
 RUN mkdir -p /home/bahmni/uploaded-files/elis/
 
 RUN yum install -y unzip
+RUN yum install -y nc
+RUN yum install -y postgresql
 
+ADD https://raw.githubusercontent.com/eficode/wait-for/v2.2.3/wait-for wait-for.sh
 ADD https://repo.mybahmni.org/packages/build/bahmni-embedded-tomcat-8.0.42.jar /opt/bahmni-lab/lib/bahmni-lab.jar
 COPY openelis/dist/openelis.war /etc/bahmni-lab/openelis.war
 
@@ -30,6 +33,9 @@ RUN yum install -y gettext
 COPY package/docker/openelis/templates/hibernate.cfg.xml.template /etc/bahmni-lab/
 COPY package/docker/openelis/templates/atomfeed.properties.template /etc/bahmni-lab/
 COPY package/resources/log4j2.xml ${WAR_DIRECTORY}/WEB-INF/classes/
+COPY package/docker/openelis/update_openmrs_host_port.sh update_openmrs_host_port.sh
+RUN chmod +x update_openmrs_host_port.sh
+RUN chmod +x wait-for.sh
 
 COPY OpenElis.zip /tmp/artifacts/
 RUN unzip -d /tmp/artifacts/ /tmp/artifacts/OpenElis.zip

--- a/package/docker/openelis/start.sh
+++ b/package/docker/openelis/start.sh
@@ -8,12 +8,15 @@ replaceConfigFiles(){
     envsubst < /etc/bahmni-lab/hibernate.cfg.xml.template > ${HIBERNATE_CONFIG_FILE}
 }
 
+echo "Waiting for ${OPENELIS_DB_SERVER}:5432 for 3600 seconds"
+sh wait-for.sh --timeout=3600 ${OPENELIS_DB_SERVER}:5432
 # Linking bahmni config
 rm -rf /var/www/bahmni_config/
 mkdir -p /var/www/bahmni_config/
 ln -s /etc/bahmni_config/openelis /var/www/bahmni_config/openelis
 
 replaceConfigFiles
+./update_openmrs_host_port.sh
 echo "[INFO] Running Default Liquibase migrations"
 cd /opt/bahmni-lab/migrations/liquibase/ && sh /opt/bahmni-lab/migrations/scripts/migrateDb.sh
 echo "[INFO] Running User Defined Liquibase migrations"

--- a/package/docker/openelis/update_openmrs_host_port.sh
+++ b/package/docker/openelis/update_openmrs_host_port.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set +e
+
+run_sql() {
+  #TODO: Remove hardcoded password and use env variable --> BAH-3394
+  PGPASSWORD="clinlims" psql --host="${OPENELIS_DB_SERVER}" -U clinlims -d clinlims -t -c "$1"
+}
+
+if [ $(run_sql "select count(*) from information_schema.tables where table_name='markers' and table_schema='clinlims';") -gt 0 ]
+then
+    echo "Updating OpenMRS Host Port in markers and failed_events table"
+    run_sql "UPDATE markers SET feed_uri_for_last_read_entry = regexp_replace(feed_uri_for_last_read_entry, 'http://.*/openmrs', 'http://${OPENMRS_HOST}:${OPENMRS_PORT}/openmrs'),feed_uri = regexp_replace(feed_uri, 'http://.*/openmrs', 'http://${OPENMRS_HOST}:${OPENMRS_PORT}/openmrs') where feed_uri ~ 'openmrs';"
+    run_sql "UPDATE failed_events SET feed_uri = regexp_replace(feed_uri, 'http://.*/openmrs', 'http://${OPENMRS_HOST}:${OPENMRS_PORT}/openmrs') where feed_uri ~'openmrs';"
+fi


### PR DESCRIPTION
This PR adds a script to update the host and port config of OpenMRS in the markers and failed_events table of openelis database. This is needed for the atomfeed to process properly when host and port config is updated.

Also a wait for script is added to wait for initialisation of openelis database service 