### PR TITLE
BAH-2916 | Fix. Lab Result Value Sync Issue in Clinical Dashboard

### DIFF
--- a/openelis/src/org/bahmni/feed/openelis/feed/service/impl/AccessionService.java
+++ b/openelis/src/org/bahmni/feed/openelis/feed/service/impl/AccessionService.java
@@ -158,7 +158,7 @@ public class AccessionService {
     }
 
     private String toISODateFormat(Timestamp timestamp){
-        return DateFormatUtils.format(timestamp.getTime(),DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.getPattern());
+        return DateFormatUtils.format(timestamp.getTime(), DateFormatUtils.ISO_DATETIME_FORMAT.getPattern());
     }
 
     private void mapSampleItem(List<TestDetail> testDetails, SampleItem sampleItem) {

--- a/openelis/src/org/bahmni/feed/openelis/feed/service/impl/AccessionService.java
+++ b/openelis/src/org/bahmni/feed/openelis/feed/service/impl/AccessionService.java
@@ -157,7 +157,7 @@ public class AccessionService {
         return accessionNotesToPublish;
     }
 
-    private String toISODateFormat(Timestamp timestamp){
+    String toISODateFormat(Timestamp timestamp){
         return DateFormatUtils.format(timestamp.getTime(), DateFormatUtils.ISO_DATETIME_FORMAT.getPattern());
     }
 

--- a/openelis/test/org/bahmni/feed/openelis/feed/service/impl/AccessionServiceTest.java
+++ b/openelis/test/org/bahmni/feed/openelis/feed/service/impl/AccessionServiceTest.java
@@ -47,8 +47,12 @@ import us.mn.state.health.lims.siteinformation.valueholder.SiteInformation;
 import us.mn.state.health.lims.systemuser.dao.SystemUserDAO;
 import us.mn.state.health.lims.testresult.valueholder.TestResult;
 
+import java.sql.Timestamp;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -224,6 +228,19 @@ public class AccessionServiceTest {
 
         assertNull(testDetail.getResultUuid());
         assertEquals("10", testDetail.getResult());
+    }
+
+    @Test
+    public void shouldReturnISODateFormat() throws ParseException {
+        AccessionService accessionService = new TestableAccessionService(sampleDao, sampleHumanDAO, externalReferenceDao, noteDao, dictionaryDao, patientIdentityDAO, patientIdentityTypeDAO, siteInformationDAO);
+        String dateString = "2024-01-22T12:34:56";
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        Date date = dateFormat.parse(dateString);
+        Timestamp timestamp = new Timestamp(date.getTime());
+
+        String result = accessionService.toISODateFormat(timestamp);
+
+        assertEquals(dateString, result);
     }
 
     private class TestableAccessionService extends AccessionService {


### PR DESCRIPTION
JIRA -> [BAH-2916](https://bahmni.atlassian.net/browse/BAH-2916)

In this PR, the dateTimeFormat of the accessionNote has been modified to resolve the "Unable to parse the date" issue. The dateTime format now aligns with the format used in the OpenELisAccessionEventWorker. This modification ensures the display of lab result values in the clinical dashboard.