### PR TITLE
BAH-3646 | Add. Event Trigger To Publish OpenELIS

### DIFF
--- a/.github/workflows/build_publish_openelis.yml
+++ b/.github/workflows/build_publish_openelis.yml
@@ -6,9 +6,14 @@ on:
       - 'release-*'
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
-
     paths-ignore:
       - '**.md'
+  workflow_run:
+    workflows: [Pull Translations from Transifex]
+    types: [completed]
+    branches:
+      - master
+      - 'release-*'
 
 jobs:
   docker-build-publish:


### PR DESCRIPTION
JIRA -> [BAH-3646](https://bahmni.atlassian.net/browse/BAH-3646)

In this PR, an workflow based event trigger has been added to the `Build and Publish OpenELIS` workflow. The `Build and Publish OpenELIS` workflow was not getting triggered as the commit action in the `Pull Translations From Transifex` workflow run can’t trigger a new workflow run [(Refer comment)](https://github.com/orgs/community/discussions/27028#discussioncomment-3254360). The changes added will programmatically trigger `Build and Publish OpenELIS` once the `Pull Translations From Transifex` workflow is successfully completed.