### PR TITLE
BAH-3908 | Migrations to update datatype of name and description columns for test and panel

### DIFF
--- a/liquibase/Bahmni/BahmniConfig.xml
+++ b/liquibase/Bahmni/BahmniConfig.xml
@@ -1821,5 +1821,29 @@
             WHERE name = 'accessionStrategy';
         </sql>
     </changeSet>
+
+    <changeSet id="BAH3908_test_table" context="bahmni" author="Mohankumar" >
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="test" columnName="name"/>
+            <columnExists tableName="test" columnName="description"/>
+        </preConditions>
+        <comment>Extend the size of name and description columns of Test table</comment>
+        <sql>
+            ALTER TABLE test ALTER COLUMN name TYPE varchar(256);
+            ALTER TABLE test ALTER COLUMN description TYPE varchar(256);
+        </sql>
+    </changeSet>
+    <changeSet id="BAH3908_panel_table" context="bahmni" author="Mohankumar" >
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="panel" columnName="name"/>
+            <columnExists tableName="panel" columnName="description"/>
+        </preConditions>
+        <comment>Extend the size of name and description columns of Panel table</comment>
+        <sql>
+            ALTER TABLE panel ALTER COLUMN name TYPE varchar(256);
+            ALTER TABLE panel ALTER COLUMN description TYPE varchar(256);
+        </sql>
+    </changeSet>
+    
 </databaseChangeLog>
 


### PR DESCRIPTION
This PR updates the datatype of `name` and `description` columns of test and panel table of OpenELIS database in the view of supporting sync of Tests and panels from CIEL dictionary.

The datatype is updated from varchar(60) to varchar(256). The updated size is in sync with the name column of OpenMRS concept_name table.

JIRA: https://bahmni.atlassian.net/browse/BAH-3908 
Sub Teask: https://bahmni.atlassian.net/browse/BAH-3993