### PR TITLE
BAH-3994 | Sync only non-retired tests, panels and samples

### DIFF
--- a/openelis/src/org/bahmni/feed/openelis/feed/service/impl/PanelService.java
+++ b/openelis/src/org/bahmni/feed/openelis/feed/service/impl/PanelService.java
@@ -68,11 +68,16 @@ public class PanelService {
             String sysUserId = auditingService.getSysUserId();
             ExternalReference data = externalReferenceDao.getData(referenceDataPanel.getId(), CATEGORY_PANEL);
             if (data == null) {
-                Panel panel = new Panel();
-                panel = populatePanel(panel, referenceDataPanel, sysUserId);
-                panelDAO.insertData(panel);
-                saveTestsForPanel(panel, referenceDataPanel, sysUserId);
-                saveExternalReference(referenceDataPanel, panel);
+                if (referenceDataPanel.getIsActive()) {
+                    Panel panel = new Panel();
+                    panel = populatePanel(panel, referenceDataPanel, sysUserId);
+                    panelDAO.insertData(panel);
+                    saveTestsForPanel(panel, referenceDataPanel, sysUserId);
+                    saveExternalReference(referenceDataPanel, panel);
+                } else {
+                    return;
+                }
+
             } else {
                 Panel panel = panelDAO.getPanelById(String.valueOf(data.getItemId()));
                 populatePanel(panel, referenceDataPanel, sysUserId);

--- a/openelis/src/org/bahmni/feed/openelis/feed/service/impl/TestService.java
+++ b/openelis/src/org/bahmni/feed/openelis/feed/service/impl/TestService.java
@@ -99,9 +99,14 @@ public class TestService {
             Test test = new Test();
 
             if (data == null) {
-                test = populateTest(test, referenceDataTest, sysUserId, null);
-                testDAO.insertData(test);
-                saveExternalReference(referenceDataTest, test);
+                if (referenceDataTest.getIsActive()) {
+                    test = populateTest(test, referenceDataTest, sysUserId, null);
+                    testDAO.insertData(test);
+                    saveExternalReference(referenceDataTest, test);
+                }
+                else {
+                    return;
+                }
             } else {
                 test = testDAO.getTestById(String.valueOf(data.getItemId()));
                 String uuid = test.getTestSection() != null ? test.getTestSection().getUUID() : null;

--- a/openelis/src/org/bahmni/feed/openelis/feed/service/impl/TypeOfSampleService.java
+++ b/openelis/src/org/bahmni/feed/openelis/feed/service/impl/TypeOfSampleService.java
@@ -61,7 +61,12 @@ public class TypeOfSampleService {
             TypeOfSample typeOfSample = typeOfSampleDAO.getTypeOfSampleByUUID(sample.getId());
 
             if (typeOfSample == null) {
-                create(sample, sysUserId);
+                if(sample.getIsActive()){
+                    create(sample, sysUserId);
+                }
+                else{
+                    return;
+                }
             } else {
                 update(typeOfSample, sample, sysUserId);
             }


### PR DESCRIPTION
This PR enhaces the atomfeed services to create tests, panels and samples only for non-retired concepts. The retired status is checked with `isActive` field of the reference-data feed.

JIRA: https://bahmni.atlassian.net/browse/BAH-3994