### PR TITLE
BAH-3995 | Fix. Case insensitive match while getting unit of measure by name

### DIFF
--- a/openelis/src/us/mn/state/health/lims/unitofmeasure/daoimpl/UnitOfMeasureDAOImpl.java
+++ b/openelis/src/us/mn/state/health/lims/unitofmeasure/daoimpl/UnitOfMeasureDAOImpl.java
@@ -242,9 +242,9 @@ public class UnitOfMeasureDAOImpl extends BaseDAOImpl implements
 
 	public UnitOfMeasure getUnitOfMeasureByName(UnitOfMeasure unitOfMeasure) throws LIMSRuntimeException {
 		try {
-			String sql = "from UnitOfMeasure u where u.unitOfMeasureName = :param";
+			String sql = "from UnitOfMeasure u where trim(lower(u.unitOfMeasureName)) = :param";
 			org.hibernate.Query query = HibernateUtil.getSession().createQuery(sql);
-			query.setParameter("param", unitOfMeasure.getUnitOfMeasureName());
+			query.setParameter("param", unitOfMeasure.getUnitOfMeasureName().trim().toLowerCase());
 
 			List list = query.list();
 			HibernateUtil.getSession().flush();


### PR DESCRIPTION
While syncing Unit of measure from OpenMRS, ELIS creates unit of measure after doing case in-sensitive  duplicate check. But it is found that while searching for unit of measure, the search is not case in-sensitive.

This cause failure in syncing test with unit of measure having same units but different cases. Example: ng/ml and ng/mL, pg/ml and pg/mL

JIRA: https://bahmni.atlassian.net/browse/BAH-3995