### PR TITLE
Upgrade Ruby Version to 3.1

### DIFF
--- a/.github/workflows/build_publish_openelis.yml
+++ b/.github/workflows/build_publish_openelis.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
       - 'release-*'
-      - upgrade-ruby-version
+      - upgrade-ruby-verison
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
     paths-ignore:

--- a/.github/workflows/build_publish_openelis.yml
+++ b/.github/workflows/build_publish_openelis.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - 'release-*'
-      - upgrade-ruby-verison
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
     paths-ignore:

--- a/.github/workflows/build_publish_openelis.yml
+++ b/.github/workflows/build_publish_openelis.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - 'release-*'
+      - upgrade-ruby-version
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
     paths-ignore:
@@ -26,10 +27,10 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '7'
-      - name: Setup Ruby 2.5
+      - name: Setup Ruby 3.3
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 3.3
       - name: Install Compass
         run: gem install compass
       - name: Install Ant 1.9

--- a/.github/workflows/build_publish_openelis.yml
+++ b/.github/workflows/build_publish_openelis.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           ruby-version: 2.5
       - name: Install Compass
-        run: gem install compass
+        run: gem install ffi -v 1.17.0 && gem install compass
       - name: Install Ant 1.9
         run: |
           mkdir /tmp/ant

--- a/.github/workflows/build_publish_openelis.yml
+++ b/.github/workflows/build_publish_openelis.yml
@@ -27,10 +27,10 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '7'
-      - name: Setup Ruby 2.5
+      - name: Setup Ruby 3.1
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 3.1
       - name: Install Compass
         run: gem install ffi -v 1.17.0 && gem install compass
       - name: Install Ant 1.9

--- a/.github/workflows/build_publish_openelis.yml
+++ b/.github/workflows/build_publish_openelis.yml
@@ -27,10 +27,10 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '7'
-      - name: Setup Ruby 3.3
+      - name: Setup Ruby 2.5
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3
+          ruby-version: 2.5
       - name: Install Compass
         run: gem install compass
       - name: Install Ant 1.9

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ forked from OpenElis_v3.1_r2013_02_21 branch in svn
 *Requirements to build OpeneLIS*
 * `java` version <= "1.7"
 * `ant` version <= "1.9.1"
-* `ruby` version <= "2.2" and `gem install compass`
+* `ruby` version == "3.1" and `gem install compass`
 
 *To build OpenElis run*
 * `ant dist`  Creates OpenELIS War


### PR DESCRIPTION
This PR upgrades the ruby version to 3.1 from 2.5 as compass dependencies need upgraded version. Also to make it compatible we are installing a specific package ffi with a fixed version 1.17.0