### PR TITLE
Fix parentOfUploadedFilesDirectory to use Docker volume path

### DIFF
--- a/liquibase/Bahmni/BahmniConfig.xml
+++ b/liquibase/Bahmni/BahmniConfig.xml
@@ -1844,6 +1844,18 @@
             ALTER TABLE panel ALTER COLUMN description TYPE varchar(256);
         </sql>
     </changeSet>
-    
+
+    <changeSet id="fix-uploaded-files-parent-directory" context="bahmni" author="bahmni">
+        <comment>Fix parentOfUploadedFilesDirectory to match Docker volume mount path.
+            Files were being saved to /home/jss/uploaded_results/ which is not volume-mounted,
+            causing uploaded PDFs to disappear. The correct path is /home/bahmni to match
+            the Docker volume mounts for bahmni-lab-results and bahmni-uploaded-files.
+        </comment>
+        <update schemaName="clinlims" tableName="site_information">
+            <column name="value" value="/home/bahmni"/>
+            <where>name='parentOfUploadedFilesDirectory'</where>
+        </update>
+    </changeSet>
+
 </databaseChangeLog>
 


### PR DESCRIPTION
Files were being saved to /home/jss/uploaded_results/ which is ephemeral container storage. Changed to /home/bahmni to match the Docker volume mounts (bahmni-lab-results and bahmni-uploaded-files), ensuring uploaded PDF files persist across container restarts.

After fix, the uploaded file persists on Results entry screen and shows up on Bahmni Patient dashboard.

On Results entry screen;
<img width="2510" height="513" alt="image" src="https://github.com/user-attachments/assets/8a14948a-6efc-41c6-82bd-df133ff3ce27" />

Patient dashboard
<img width="1419" height="1045" alt="image" src="https://github.com/user-attachments/assets/b01cc9ec-cab2-42d8-b7f3-0f866bef4ef1" />
