### PR TITLE
Sasi | BAH-4662 | Fix the Patient Age Calculation rounding issue

### DIFF
--- a/openelis/src/us/mn/state/health/lims/common/util/DateUtil.java
+++ b/openelis/src/us/mn/state/health/lims/common/util/DateUtil.java
@@ -534,7 +534,7 @@ public class DateUtil {
 		return dMons;
 	}
 
-	public static int getAgeInYears(Date startDate, Date endDate) {
+	public static double getAgeInYears(Date startDate, Date endDate) {
 		Calendar start = new GregorianCalendar();
 		start.setTime(startDate);
 		Calendar end = new GregorianCalendar();
@@ -545,7 +545,9 @@ public class DateUtil {
 					start.get(Calendar.DAY_OF_MONTH) > end.get(Calendar.DAY_OF_MONTH))) {
 			--year;
 		}
-		return year;
+		start.add(Calendar.YEAR, year);
+		double fractionalYear = (end.getTimeInMillis() - start.getTimeInMillis()) / 31557600000.0;
+		return year + fractionalYear;
 	}
 
 	public static Timestamp getTimestampAtMidnightForDaysAgo(int days) {

--- a/openelis/test/us/mn/state/health/lims/common/util/DateUtilTest.java
+++ b/openelis/test/us/mn/state/health/lims/common/util/DateUtilTest.java
@@ -133,27 +133,27 @@ public class DateUtilTest {
     public void testAgeInYears() {
         start.set(  2011, JANUARY, 1);
         end.set(    2011, JANUARY, 17);
-        assertEquals(0, DateUtil.getAgeInYears(start.getTime(), end.getTime()));                
-        
+        assertEquals(0.044, DateUtil.getAgeInYears(start.getTime(), end.getTime()), 0.01);
+
         start.set(  2011, JANUARY, 17);
         end.set(    2011, DECEMBER, 1);
-        assertEquals(0, DateUtil.getAgeInYears(start.getTime(), end.getTime()));                
+        assertEquals(0.870, DateUtil.getAgeInYears(start.getTime(), end.getTime()), 0.01);
 
         start.set(  2011, JANUARY, 17);
         end.set(    2012, JANUARY, 16);
-        assertEquals(0, DateUtil.getAgeInYears(start.getTime(), end.getTime()));
-        
+        assertEquals(0.997, DateUtil.getAgeInYears(start.getTime(), end.getTime()), 0.01);
+
         start.set(  2011, JANUARY, 17);
         end.set(    2012, JANUARY, 17);
-        assertEquals(1, DateUtil.getAgeInYears(start.getTime(), end.getTime()));
-        
+        assertEquals(1.0, DateUtil.getAgeInYears(start.getTime(), end.getTime()), 0.01);
+
         start.set(  2011, JANUARY, 17);
         end.set(    2012, JANUARY, 18);
-        assertEquals(1, DateUtil.getAgeInYears(start.getTime(), end.getTime()));                
+        assertEquals(1.003, DateUtil.getAgeInYears(start.getTime(), end.getTime()), 0.01);
 
         start.set(  2011, JANUARY, 17);
         end.set(    2021, JANUARY, 18);
-        assertEquals(10, DateUtil.getAgeInYears(start.getTime(), end.getTime()));                
+        assertEquals(10.003, DateUtil.getAgeInYears(start.getTime(), end.getTime()), 0.01);                
     }
 
     @Test


### PR DESCRIPTION
There is an issue with age calculation that causes OpenELIS to truncate the ages of neonates and infants under 1 year to 0 years. This impacts laboratories by preventing them from accurately setting and triggering specific test result reference limits for different neonatal age phases.

**Expected behaviour**
The system should evaluate a 28-day-old patient as approximately 0.076 years old. This would allow the correct neonate result limit bracket to be triggered.

**Current behaviour**
The system currently calculates the age of a 28-day-old patient as exactly 0.0 years. This truncation leads to incorrect limit matching, potentially triggering the wrong limit block.

**Fix**
Advances the Start Date: It adds the already-calculated whole year variable to the start calendar object.

Calculates the Remainder: It finds the remaining time gap between this updated start date and the end date in milliseconds.

Converts to Fraction: It divides those leftover milliseconds by 31,557,600,000.0 (the standard number of milliseconds in a 365.25-day year) to determine the exact fractional year.

Returns the Total: It adds the whole years and the fractional year together to return the final, highly precise duration.

**Jira Card**: https://bahmni.atlassian.net/browse/BAH-4662